### PR TITLE
address Issues #1 and #3

### DIFF
--- a/Classes/Repository/PageRepository.php
+++ b/Classes/Repository/PageRepository.php
@@ -39,35 +39,22 @@ class PageRepository
      * Find navigation pages by parent UID
      *
      * @param int $parentUid The parent page UID
-     * @param int[] $excludeDoktypes Array of doktype integers to exclude from results
      * @return array Array of page data
      */
-    public function findNavigationByParent(int $parentUid, array $excludeDoktypes = []): array
+    public function findNavigationByParent(int $parentUid): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
         $queryBuilder->getRestrictions()->removeAll()
             ->add(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
 
-        $queryBuilder
+        $result = $queryBuilder
             ->select('uid', 'pid', 'title', 'description', 'abstract', 'nav_title', 'doktype')
             ->from('pages')
             ->where(
                 $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($parentUid)),
                 $queryBuilder->expr()->eq('nav_hide', $queryBuilder->createNamedParameter(0)),
                 $queryBuilder->expr()->eq('no_index', $queryBuilder->createNamedParameter(0))
-            );
-
-        // Exclude specified doktypes if provided
-        if (!empty($excludeDoktypes)) {
-            $queryBuilder->andWhere(
-                $queryBuilder->expr()->notIn(
-                    'doktype',
-                    $queryBuilder->createNamedParameter($excludeDoktypes, \TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY)
-                )
-            );
-        }
-
-        $result = $queryBuilder
+            )
             ->orderBy('sorting')
             ->executeQuery();
 

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -126,4 +126,24 @@ class ConfigurationService
 
         return (int)($site->getConfiguration()['llmsTxtMaxDepth'] ?? 2);
     }
+
+    /**
+     * Get the list of doktypes to exclude from navigation
+     *
+     * @return int[] Array of doktype integers to exclude
+     */
+    public function getExcludeDoktypes(): array
+    {
+        $site = $this->getCurrentSite();
+        if ($site === null) {
+            return [];
+        }
+
+        $doktypes = $site->getConfiguration()['llmsTxtExcludeDoktypes'] ?? '';
+        if (empty($doktypes)) {
+            return [];
+        }
+
+        return array_map('intval', array_filter(array_map('trim', explode(',', $doktypes)), 'is_numeric'));
+    }
 }

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -20,12 +20,12 @@ class ConfigurationService
 
     protected function getCurrentSite(): ?Site
     {
-        $sites = $this->siteFinder->getAllSites();
-        if (empty($sites)) {
+        $pageId = (int)($GLOBALS['TSFE']->id ?? 0);
+        if ($pageId === 0) {
             return null;
         }
 
-        return reset($sites);
+        return $this->siteFinder->getSiteByPageId($pageId);
     }
 
     public function getSiteUrl(): string

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -81,6 +81,16 @@ $GLOBALS['SiteConfiguration']['site']['columns']['llmsTxtMaxDepth'] = [
     ],
 ];
 
+$GLOBALS['SiteConfiguration']['site']['columns']['llmsTxtExcludeDoktypes'] = [
+    'label' => 'LLL:EXT:ai_llms_txt/Resources/Private/Language/locallang.xlf:site.llmsTxtExcludeDoktypes',
+    'description' => 'LLL:EXT:ai_llms_txt/Resources/Private/Language/locallang.xlf:site.llmsTxtExcludeDoktypes.description',
+    'config' => [
+        'type' => 'input',
+        'eval' => 'trim',
+        'placeholder' => 'LLL:EXT:ai_llms_txt/Resources/Private/Language/locallang.xlf:site.llmsTxtExcludeDoktypes.placeholder',
+    ],
+];
+
 if (!isset($GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'])) {
     $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] = '';
 }
@@ -93,5 +103,6 @@ $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ',
         llmsTxtAdditionalInfo,
         llmsTxtContactEmail,
         llmsTxtKeywords,
-        llmsTxtMaxDepth
+        llmsTxtMaxDepth,
+        llmsTxtExcludeDoktypes
 ';

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -125,6 +125,15 @@
 			<trans-unit id="site.llmsTxtMaxDepth.description">
 				<source>Maximum depth of page hierarchy to include in navigation (1-5 levels)</source>
 			</trans-unit>
+			<trans-unit id="site.llmsTxtExcludeDoktypes">
+				<source>Exclude Page Types (Doktypes)</source>
+			</trans-unit>
+			<trans-unit id="site.llmsTxtExcludeDoktypes.description">
+				<source>Comma-separated list of page doktypes to exclude from the llms.txt navigation output (e.g., "254,4" to exclude folders and shortcuts)</source>
+			</trans-unit>
+			<trans-unit id="site.llmsTxtExcludeDoktypes.placeholder">
+				<source>254,4</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
I've implemented a configurable filter for doktype-excludes:
- llmsTxtExcludeDoktypes can be configured in site-settings (eg "3,6,7,199,254,255")
- pages matching the excluded doktypes are filtered out from the final output
- page-traversal is still done to account for special nested structures in the backend eg when a site uses folders to separate navigation-sections

also I've added the proposed fix from Issue #3 to use multi-sites.