### PR TITLE
[CHANGE] Fix seo_title and description localization in markdown output

### DIFF
--- a/Classes/Controller/LlmsTxtController.php
+++ b/Classes/Controller/LlmsTxtController.php
@@ -85,13 +85,17 @@ class LlmsTxtController
         $cObject->start([], 'pages');
 
         $pageId = $this->configurationService->getCurrentPageId();
+        // Get current language UID for proper localization
+        $languageUid = $this->getLanguageUid();
 
-        $page = $this->pageRepository->findById($pageId);
+        $page = $this->pageRepository->findById($pageId, $languageUid);
 
         $html = '';
 
-        if (!empty($page['title'])) {
-            $html .= '<h1>' . htmlspecialchars($page['title']) . '</h1>';
+        // Use seo_title if available, otherwise fall back to title
+        $displayTitle = !empty($page['seo_title']) ? $page['seo_title'] : $page['title'];
+        if (!empty($displayTitle)) {
+            $html .= '<h1>' . htmlspecialchars($displayTitle) . '</h1>';
         }
 
         if (!empty($page['description'])) {
@@ -115,5 +119,30 @@ class LlmsTxtController
         }
 
         return $html;
+    }
+
+    /**
+     * Get the current language UID from TYPO3 frontend environment
+     * Checks sys_language_uid first, falls back to page['sys_language_uid']
+     */
+    protected function getLanguageUid(): int
+    {
+        // Try to get language from TSFE->sys_language_uid
+        if (isset($GLOBALS['TSFE']) && isset($GLOBALS['TSFE']->sys_language_uid)) {
+            $langUid = (int)$GLOBALS['TSFE']->sys_language_uid;
+            if ($langUid > 0) {
+                return $langUid;
+            }
+        }
+
+        // Fallback: get language from current page data
+        if (isset($GLOBALS['TSFE']) && isset($GLOBALS['TSFE']->page)) {
+            $page = $GLOBALS['TSFE']->page;
+            if (is_array($page) && isset($page['sys_language_uid'])) {
+                return (int)$page['sys_language_uid'];
+            }
+        }
+
+        return 0;
     }
 }

--- a/Classes/Repository/PageRepository.php
+++ b/Classes/Repository/PageRepository.php
@@ -63,18 +63,26 @@ class PageRepository
     }
 
     /**
-     * Find a page by its UID
+     * Find a page by its UID with optional language support
      *
-     * @return array{uid: int, title: string, subtitle: string, description: string, abstract: string}|array{}
+     * @return array{uid: int, title: string, subtitle: string, seo_title: string, description: string, abstract: string}|array{}
      */
-    public function findById(int $pageId): array
+    public function findById(int $pageId, int $languageUid = 0): array
     {
+        // Fetch localized page if language is specified
+        if ($languageUid > 0) {
+            $localizedPage = $this->getLocalizedPage($pageId, $languageUid);
+            if (!empty($localizedPage)) {
+                return $localizedPage;
+            }
+        }
+
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
         $queryBuilder->getRestrictions()->removeAll()
             ->add(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
 
         $result = $queryBuilder
-            ->select('uid', 'title', 'subtitle', 'description', 'abstract')
+            ->select('uid', 'title', 'subtitle', 'seo_title', 'description', 'abstract')
             ->from('pages')
             ->where(
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($pageId, Connection::PARAM_INT))
@@ -82,6 +90,49 @@ class PageRepository
             ->executeQuery();
 
         return $result->fetchAssociative() ?: [];
+    }
+
+    /**
+     * Fetch localized page by l10n_parent and sys_language_uid
+     * Falls back to unrestricted query if FrontendRestrictionContainer filters result
+     *
+     * @return array{uid: int, title: string, subtitle: string, seo_title: string, description: string, abstract: string}|array{}
+     */
+    private function getLocalizedPage(int $pageId, int $languageUid): array
+    {
+        // First try with FrontendRestrictionContainer
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
+
+        $result = $queryBuilder
+            ->select('uid', 'title', 'subtitle', 'seo_title', 'description', 'abstract')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq('l10n_parent', $queryBuilder->createNamedParameter($pageId, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($languageUid, Connection::PARAM_INT))
+            )
+            ->executeQuery();
+
+        $localizedPage = $result->fetchAssociative();
+        if ($localizedPage) {
+            return $localizedPage;
+        }
+
+        // Fallback: query without FrontendRestrictionContainer
+        $queryBuilder2 = $this->connectionPool->getQueryBuilderForTable('pages');
+        $queryBuilder2->getRestrictions()->removeAll();
+
+        $result2 = $queryBuilder2
+            ->select('uid', 'title', 'subtitle', 'seo_title', 'description', 'abstract')
+            ->from('pages')
+            ->where(
+                $queryBuilder2->expr()->eq('l10n_parent', $queryBuilder2->createNamedParameter($pageId, Connection::PARAM_INT)),
+                $queryBuilder2->expr()->eq('sys_language_uid', $queryBuilder2->createNamedParameter($languageUid, Connection::PARAM_INT))
+            )
+            ->executeQuery();
+
+        return $result2->fetchAssociative() ?: [];
     }
 
     /**


### PR DESCRIPTION
Problem: The seo_title and description fields were always displayed in the default language (German) instead of the requested foreign language (French) when accessing markdown output via pageType 1701.

Root Cause: The PageRepository::findById() method was not selecting the seo_title field and did not support language parameter. The controller was not detecting or passing the current language context to the repository.

Solution:

PageRepository::findById() - Enhanced method signature:

Added optional $languageUid = 0 parameter for language-aware fetching
Added seo_title field to SELECT clause
Implemented getLocalizedPage() private method to fetch translated pages using l10n_parent and sys_language_uid fields
Added fallback to unrestricted query if FrontendRestrictionContainer filters result
LlmsTxtController::getRenderedPageContent() - Language detection:

Added call to getLanguageUid() to detect current language context
Pass language UID to findById() method
Updated display logic to prefer seo_title with fallback to title
LlmsTxtController::getLanguageUid() - New helper method:

Reads language from $GLOBALS['TSFE']->sys_language_uid
Falls back to $GLOBALS['TSFE']->page['sys_language_uid']
Returns 0 (default language) if no language context found
Result: The plugin now correctly displays localized seo_title and description fields in the markdown output when accessing different language versions of the site.